### PR TITLE
Adding docker support for use in Cbrain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Installs ICA-AROMA to a centos image with FSL pre-installed
-FROM taumen/centos-fsl-5:latest
+FROM mcin/centos-fsl-5:latest
 
 # Install necessary python packages
 RUN yum update -y; yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Installs ICA-AROMA to a centos image with FSL pre-installed
+FROM taumen/centos-fsl-5:latest
+
+# Install necessary python packages
+RUN yum update -y; yum clean all
+RUN yum install -y numpy scipy
+
+# Add everything to the container
+ADD . /ICA-AROMA
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Installs ICA-AROMA to a centos image with FSL pre-installed
-FROM mcin/centos-fsl-5:latest
+FROM mcin/docker-fsl:latest
 
 # Install necessary python packages
 RUN yum update -y; yum clean all

--- a/ica-aroma-wrapper.py
+++ b/ica-aroma-wrapper.py
@@ -1,0 +1,21 @@
+# Simple wrapper for the ICA-AROMA python scripts, to hand them absolute paths.
+# Required to make the tool work in cbrain via the docker container
+
+import os, sys
+from subprocess import Popen
+
+# Input arguments
+args = sys.argv[1:]
+
+# Modify the arguments for existent files and the output dir to be absolute paths
+mod_args = [(os.path.abspath(f) if os.path.exists(f) else f) for f in args]
+targ_ind = mod_args.index("-out") + 1
+mod_args[targ_ind] = os.path.abspath(mod_args[targ_ind])
+
+# Call the ICA-AROMA process
+cmd = "python /ICA-AROMA/ICA_AROMA.py " + " ".join(mod_args)
+print("Running: " + cmd + "\n")
+process = Popen( cmd.split() ) 
+sys.exit( process.wait() )
+
+


### PR DESCRIPTION
We are trying to integrate the ICA-AROMA tool in CBrain, using a docker container for portability. This entails using a Dockerfile for building the container and a wrapper script for use in CBrain. However, we felt it would be better for your official github repository to be used for storing these if possible. 

Also, currently, we are using an automated Docker build linked to our own fork of ICA-AROMA; however, if you would prefer to have an official dockerhub and container, we would switch to that one. 