### PR TITLE
FIX: maxRPcorr NaNs

### DIFF
--- a/ICA_AROMA_functions.py
+++ b/ICA_AROMA_functions.py
@@ -270,7 +270,7 @@ def feature_time_series(melmix, mc):
 		maxTC[i,:] = corMatrixAbs.max(axis=1)
 
 	# Get the mean maximum correlation over all random splits
-	maxRPcorr = maxTC.mean(axis=0)
+	maxRPcorr = np.nanmean(maxTC, axis=0)
 
 	# Return the feature score
 	return maxRPcorr

--- a/ICA_AROMA_functions.py
+++ b/ICA_AROMA_functions.py
@@ -270,6 +270,7 @@ def feature_time_series(melmix, mc):
 		maxTC[i,:] = corMatrixAbs.max(axis=1)
 
 	# Get the mean maximum correlation over all random splits
+	# nanmean to deal with occasional nans popping up in the correlation calculation
 	maxRPcorr = np.nanmean(maxTC, axis=0)
 
 	# Return the feature score


### PR DESCRIPTION
see poldracklab/fmriprep#578

This bug was found for a subject in the testing suite of fmriprep. A couple of the 1,000 iterations calculating  maxRPcorr resulted in nans. The proposed pull request ignores the nans in the averaging calculation, which is safe in this scenario since there were few nans in the result ([see attached python notebook for the recreation of the issue](https://drive.google.com/file/d/0B9eMc5Q-tEdSUUVkTnA5d0Zydlk/view?usp=sharing)).