### PR TITLE
The indent is fixed.

### DIFF
--- a/ICA_AROMA_functions.py
+++ b/ICA_AROMA_functions.py
@@ -531,10 +531,10 @@ def denoising(fslDir, inFile, outDir, melmix, denType, denIdx):
 	if check==1:
 		# Put IC indices into a char array
                 if denIdx.size == 1:
-                  denIdxStrJoin =  "%d"%(denIdx+1)
+                    denIdxStrJoin =  "%d"%(denIdx+1)
                 else:
-		  denIdxStr = np.char.mod('%i',(denIdx+1))
-                  denIdxStrJoin =  ','.join(denIdxStr)
+                    denIdxStr = np.char.mod('%i',(denIdx+1))
+                    denIdxStrJoin =  ','.join(denIdxStr)
 
 		# Non-aggressive denoising of the data using fsl_regfilt (partial regression), if requested
 		if (denType == 'nonaggr') or (denType == 'both'):		


### PR DESCRIPTION
The indent in line 536 sounds correct in github; but after cloning or downloading the code, the indent is missing! The problem might affect the denoising results (in my case it does not create the nonaggr denoised file). 
I have just added some tabs for the indents to fix the problem.